### PR TITLE
remove-destructing-requiry

### DIFF
--- a/packages/eslint-config-qlean-react-native/index.js
+++ b/packages/eslint-config-qlean-react-native/index.js
@@ -18,7 +18,8 @@ module.exports = {
     "react-native/split-platform-components": 2,
     "react-native/no-inline-styles": 2,
     "react-native/no-color-literals": 2,
-    "no-loops/no-loops": 2
+    "no-loops/no-loops": 2,
+    "react/destructuring-assignment": ["always", { "ignoreClassFields": true }]
   },
   "globals": {
     "__DEV__": true

--- a/packages/eslint-config-qlean-react-native/package.json
+++ b/packages/eslint-config-qlean-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-qlean-react-native",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Qlean ESLint config for React Native",
   "main": "index.js",
   "peerDependencies": {

--- a/packages/eslint-config-qlean/index.js
+++ b/packages/eslint-config-qlean/index.js
@@ -23,6 +23,7 @@ module.exports = {
       "beforeSelfClosing": "never",
       "afterOpening": "never"
     }],
-    "no-loops/no-loops": 2
+    "no-loops/no-loops": 2,
+    "react/destructuring-assignment": ["always", { "ignoreClassFields": true }]
   },
 };

--- a/packages/eslint-config-qlean/package.json
+++ b/packages/eslint-config-qlean/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-qlean",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Qlean ESLint config for React",
   "main": "index.js",
   "peerDependencies": {


### PR DESCRIPTION
Мне не очень нравится новое правило из airbnb конфига:
https://github.com/airbnb/javascript/blob/685f37be39fd01bcfdd349de9acdcd5a50414520/packages/eslint-config-airbnb/rules/react.js#L422

Это правило ругается каждый раз, когда мы **не** деструктируем `this.props`.
```js
componentDidMount() {
  this.props.fetchUser(); // Будет ругаться
}

componentDidMount() {
  const { fetchUser } = this.props;
  fetchUser(); // Не будет ругаться
}
```
Когда `this.props` используется один раз внутри функции - кажется удобнее не деструктировать.

Можем либо совсем отключить правило, либо как предложено в PR, хотя бы внутри классов React (думаю так будет хорошо).

P.S. Не вижу смысла задачу создавать, тем самым удваивать временные затраты на эту мелочь.